### PR TITLE
Fix broken layout of container preview

### DIFF
--- a/src/folder.view/usr/local/emhttp/plugins/folder.view/scripts/docker.js
+++ b/src/folder.view/usr/local/emhttp/plugins/folder.view/scripts/docker.js
@@ -193,7 +193,10 @@ const createFolder = (folder, id, position, order, containersInfo, foldersDone) 
     switch (folder.settings.preview) {
         case 1:
             addPreview = (id, ctid, autostart) => {
-                $(`tr.folder-id-${id} div.folder-preview`).append($(`tr.folder-id-${id} div.folder-storage > tr > td.ct-name > span.outer:last`).clone().addClass(`${autostart ? 'autostart' : ''}`));
+                let clone = $(`tr.folder-id-${id} div.folder-storage > tr > td.ct-name > span.outer:last`).clone();
+                clone.find(`span.state`)[0].innerHTML = clone.find(`span.state`)[0].innerHTML.split("<br>")[0];
+                $(`tr.folder-id-${id} div.folder-preview`).append(clone.addClass(`${autostart ? 'autostart' : ''}`));
+
                 let tmpId = $(`tr.folder-id-${id} div.folder-preview > span.outer:last`).find('i[id^="load-"]');
                 tmpId.attr("id", "folder-" + tmpId.attr("id"));
                 if(folder.settings.context === 2 || folder.settings.context === 0) {
@@ -222,7 +225,10 @@ const createFolder = (folder, id, position, order, containersInfo, foldersDone) 
             break;
         case 3:
             addPreview = (id, ctid, autostart) => {
-                $(`tr.folder-id-${id} div.folder-preview`).append($(`tr.folder-id-${id} div.folder-storage > tr > td.ct-name > span.outer > span.inner:last`).clone().addClass(`${autostart ? 'autostart' : ''}`));
+                let clone = $(`tr.folder-id-${id} div.folder-storage > tr > td.ct-name > span.outer > span.inner:last`).clone();
+                clone.find(`span.state`)[0].innerHTML = clone.find(`span.state`)[0].innerHTML.split("<br>")[0];
+                $(`tr.folder-id-${id} div.folder-preview`).append(clone.addClass(`${autostart ? 'autostart' : ''}`));
+                
                 let tmpId = $(`tr.folder-id-${id} div.folder-preview > span.inner:last`).find('i[id^="load-"]');
                 tmpId.attr("id", "folder-" + tmpId.attr("id"));
 


### PR DESCRIPTION
Unraid 7.0.0 added a new line containing the Compose Stack to the docker state.

This broke the preview layouts containing the state label. This commit aims to remove the Compose Stack information from the preview to restore the original layout.

Broken Layout:
Icon + Label
![image](https://github.com/user-attachments/assets/c6433dc2-05ff-4caf-9b62-0866570fba24)

Label Only
![image](https://github.com/user-attachments/assets/315a3a2b-7d03-4e6e-b4d9-9292fc436f06)



Fixed Layout:
Icon + Label
![image](https://github.com/user-attachments/assets/0730afd9-d4e3-4f7b-8cbd-656c601f7f9b)

Label Only
![image](https://github.com/user-attachments/assets/b56c9b28-37fe-4907-82d6-42f99400bcec)
