### PR TITLE
fix: fixes button layout issue for containers created by compose

### DIFF
--- a/src/folder.view/usr/local/emhttp/plugins/folder.view/styles/docker.css
+++ b/src/folder.view/usr/local/emhttp/plugins/folder.view/styles/docker.css
@@ -48,11 +48,24 @@
     margin-top: 7px;
 }
 
+.folder-preview-wrapper .inner {
+    width: 12em;
+    overflow: hidden;
+    position: relative;
+}
+
 .folder-preview-wrapper .inner > span.appname {
     display: inline-block;
     overflow: clip;
     white-space: nowrap;
     word-break: break-all;
+}
+
+.folder-preview-wrapper .inner > span.state {
+    display: inline-block;
+    overflow: hidden;
+    height: 1em;
+    width: 6em;
 }
 
 .folder-preview-divider:not(:last-child) {
@@ -65,8 +78,23 @@
 }
 
 .folder-element-custom-btn {
-    margin-left: 0.5em;
+    /* margin-left: 0.5em; */
+    position: absolute;
+    bottom: 0;
 }
+
+.folder-preview-wrapper .inner > span.folder-element-webui {
+    right: 2.6em;
+}
+
+.folder-preview-wrapper .inner > span.folder-element-console {
+    right: 1.3em;
+}
+
+.folder-preview-wrapper .inner > span.folder-element-logs {
+    right: 0;
+}
+
 
 div.folder-preview img.img {
     margin-right: 4px;


### PR DESCRIPTION
This fixes the layout caused when containers are created by docker compose as per this issue:
https://forums.unraid.net/topic/142782-plugin-folderview/page/39/#findComment-1543722

The issue is caused by the new line with "Compose Stack: .....". This throws off sizing.  I set that span to 1em height with overflow hidden.
I also set a width for each container and positioned the buttons using absolute positioning to make all containers line up nicely.  This could be removed if people prefer the containers to be different widths.

Note: this is a different approach to #11 and only edits the CSS